### PR TITLE
Added Moraru's No fire on Base

### DIFF
--- a/7Cav-Alive.Altis/initPlayerLocal.sqf
+++ b/7Cav-Alive.Altis/initPlayerLocal.sqf
@@ -46,5 +46,14 @@ player addEventHandler ["HandleRating", { 0 }];
 // };
 // [CLIENT_CommandChatHandler] call JB_fnc_chatAddEventHandler;
 
+// Load no fire on base script
+player addEventHandler ["Fired", {
+	if ((getPos (_this select 0)) inArea headquarters)  then	
+	{
+		deleteVehicle (_this select 6);
+		titleText ["Firing weapons and placing / throwing explosives at base is STRICTLY PROHIBITED!", "PLAIN", 3];
+	};
+}]; 
+
 CLIENT_InitPlayerLocalComplete = true;
 diag_log "initPlayerLocal end";


### PR DESCRIPTION
From previous PR for no fire on base, just the snipplet of code from moraru.
This requires the trigger "Headquarters" to be set on the sqm otherwise get errors

This pull request will:
Add more code to the playerlocalinit file.
Remove ability to fire on base as long as within trigger area of "Headquarters" in the mission sqm.


This pull request resolves the following issues:
Fixes:
Players being able to fire on base.

Notes:
Sorry about the branch spam, cherry picking commits is no bueno
