### PR TITLE
Revamped Logistics Box spawner list

### DIFF
--- a/7Cav-Alive.Altis/scripts/client/ammoBoxList.sqf
+++ b/7Cav-Alive.Altis/scripts/client/ammoBoxList.sqf
@@ -34,8 +34,12 @@ CLIENT_SpawnAtBox = {
 
   _crate = [_position, "Box_NATO_WpsLaunch_F"] call CLIENT_SpawnBox;
 
-  _crate addWeaponCargoGlobal ["launch_MRAWS_green_F", 3];  
-  _crate addMagazineCargoGlobal ["MRAWS_HEAT_F", 17];
+  _crate addWeaponCargoGlobal ["rhs_weap_maaws", 2];  
+  _crate addMagazineCargoGlobal ["rhs_mag_maaws_HEAT", 10];
+  _crate addMagazineCargoGlobal ["rhs_mag_maaws_HEDP", 5];
+  _crate addItemCargoGlobal ["rhs_optic_maaws", 2];
+  _crate addWeaponCargoGlobal ["rhs_weap_m72a7", 4];
+  _crate addWeaponCargoGlobal ["rhs_weap_M136_hedp", 2];
 };
 
 CLIENT_SpawnAmmoBox = {
@@ -83,4 +87,65 @@ CLIENT_SpawnJavelinBox = {
 
   _crate addWeaponCargoGlobal ["rhs_weap_fgm148", 1]; 
   _crate addMagazineCargoGlobal ["rhs_fgm148_magazine_AT", 5]; 
+};
+
+CLIENT_SpawnHMGBox = {
+  params ["_position"];
+
+  _crate = [_position, "Box_NATO_Equip_F"] call CLIENT_SpawnBox;
+
+  _crate addWeaponCargoGlobal ["ace_csw_m3CarryTripodLow", 2]; 
+  _crate addWeaponCargoGlobal ["ace_csw_m3CarryTripod", 2];
+  _crate addWeaponCargoGlobal ["ace_compat_rhs_usf3_m2_carry", 2];
+  _crate addMagazineCargoGlobal ["ace_csw_100Rnd_127x99_mag_red", 20];
+};
+
+CLIENT_SpawnGMGBox = {
+  params ["_position"];
+
+  _crate = [_position, "Box_NATO_Equip_F"] call CLIENT_SpawnBox;
+
+  _crate addWeaponCargoGlobal ["ace_csw_m3CarryTripodLow", 2]; 
+  _crate addWeaponCargoGlobal ["ace_compat_rhs_usf3_mk19_carry", 2];
+  _crate addMagazineCargoGlobal ["ace_compat_rhs_usf3_48Rnd_40mm_MK19_M430A1", 20];
+};
+
+CLIENT_SpawnTOWBox = {
+  params ["_position"];
+
+  _crate = [_position, "rhsusf_spec_weapons_crate"] call CLIENT_SpawnBox;
+
+  _crate addWeaponCargoGlobal ["ace_csw_m220CarryTripod", 1]; 
+  _crate addWeaponCargoGlobal ["ace_compat_rhs_usf3_tow_carry", 1];
+  _crate addMagazineCargoGlobal ["ace_compat_rhs_usf3_mag_TOW2b", 6];
+  _crate addMagazineCargoGlobal ["ace_compat_rhs_usf3_mag_TOW2bb", 2];
+};
+
+CLIENT_SpawnAABox = {
+  params ["_position"];
+
+  _crate = [_position, "Box_EAF_WpsLaunch_F"] call CLIENT_SpawnBox;
+
+  _crate addWeaponCargoGlobal ["rhs_weap_fim92", 1]; 
+  _crate addMagazineCargoGlobal ["rhs_fim92_mag", 6];
+};
+
+CLIENT_SpawnAABox = {
+  params ["_position"];
+
+  _crate = [_position, "rhsusf_weapon_crate"] call CLIENT_SpawnBox;
+
+  _crate addWeaponCargoGlobal ["rhs_weap_M107", 1]; 
+  _crate addMagazineCargoGlobal ["rhsusf_mag_10Rnd_STD_50BMG_mk211", 5];
+  _crate addMagazineCargoGlobal ["rhsusf_mag_10Rnd_STD_50BMG_M33", 15];
+};
+
+CLIENT_SpawnAABox = {
+  params ["_position"];
+
+  _crate = [_position, "Box_NATO_Wps_F"] call CLIENT_SpawnBox;
+
+  _crate addWeaponCargoGlobal ["rhs_weap_m240G", 2]; 
+  _crate addMagazineCargoGlobal ["rhsusf_100Rnd_762x51_m80a1epr", 15];
+  _crate addMagazineCargoGlobal ["rhsusf_100Rnd_762x51_m61_ap", 5];
 };

--- a/7Cav-Alive.Altis/scripts/client/ammoBoxSpawner.sqf
+++ b/7Cav-Alive.Altis/scripts/client/ammoBoxSpawner.sqf
@@ -32,11 +32,18 @@ _this params ["_object", "_marker", "_items"];
 } forEach _items;
 
 private _ammoboxTypes = [
-  [format ["<t color='#0000FF'>Spawn Medical Crate</t>"], CLIENT_SpawnMedicalBox],
-  [format ["<t color='#0000FF'>Spawn AT Crate</t>"], CLIENT_SpawnAtBox],
-  [format ["<t color='#0000FF'>Spawn Ammo Crate</t>"], CLIENT_SpawnAmmoBox],
-  [format ["<t color='#0000FF'>Spawn Javelin Crate</t>"], CLIENT_SpawnJavelinBox],
-  [format ["<t color='#0000FF'>Spawn Night Supply Crate</t>"], CLIENT_SpawnNightBox]
+  [format ["<t color='#25b34b'>Medical Crate</t>"], CLIENT_SpawnMedicalBox],
+  [format ["<t color='#ff0000'>Mixed AT Crate</t>"], CLIENT_SpawnAtBox],
+  [format ["<t color='#0000FF'>Ammo Crate</t>"], CLIENT_SpawnAmmoBox],
+  [format ["<t color='#ff0000'>Javelin Crate</t>"], CLIENT_SpawnJavelinBox],
+  [format ["<t color='#0000FF'>Night Supply Crate</t>"], CLIENT_SpawnNightBox],
+  [format ["<t color='#ff0000'>.50Cal HMG Crate</t>"], CLIENT_SpawnHMGBox],
+  [format ["<t color='#ff0000'>Mk.19 GMG Crate</t>"], CLIENT_SpawnGMGBox],
+  [format ["<t color='#ff0000'>TOW AT Crate</t>"], CLIENT_SpawnTOWBox],
+  [format ["<t color='#ff0000'>Stinger AA Crate</t>"], CLIENT_SpawnAABox],
+  [format ["<t color='#0000FF'>Barrett .50 Anti-Materiel Crate</t>"], CLIENT_SpawnAMBox],
+  [format ["<t color='#0000FF'>240G GPMG Crate</t>"], CLIENT_SpawnGPMGBox],
+
 ];
 
 


### PR DESCRIPTION
Added HMG, GMG, GPMG, TOW, AA, and Anti-Materiel crates

Updated AT crate to now be Mixed AT crate.

This pull request will:
Adds the following crates:
- Static HMG
- Static GMG
- GPMG (240G)
- Static TOW
- AA (Stinger)
- Anti-Materiel (Barrett 50)

Updates the AT Crate to be mixed instead of pure MAAWS, removes TF47 MAAWS classnames

This pull request resolves the following issues:
Resolves #304 

Notes:
With the exception of the MAAWS (which may need to be pulled out in an emergency) no boxes contain sights or attachments. This is by design to help stop overcramming the boxes.

Just in time for the release :)